### PR TITLE
Improve news flow and related CLI commands (#1527)

### DIFF
--- a/src/leettools/chat/_impl/duckdb/history_manager_duckdb.py
+++ b/src/leettools/chat/_impl/duckdb/history_manager_duckdb.py
@@ -1,7 +1,6 @@
 import json
 import traceback
 import uuid
-from datetime import datetime
 from functools import cmp_to_key
 from typing import Any, Dict, List, Optional
 
@@ -26,7 +25,7 @@ from leettools.common.exceptions import (
 from leettools.common.logging import logger, remove_logger
 from leettools.common.logging.event_logger import EventLogger
 from leettools.common.logging.logger_for_query import get_logger_for_chat
-from leettools.common.utils import content_utils
+from leettools.common.utils import content_utils, time_utils
 from leettools.context_manager import Context
 from leettools.core.consts.article_type import ArticleType
 from leettools.core.schemas.chat_query_item import ChatQueryItem, ChatQueryItemCreate
@@ -95,7 +94,7 @@ class HistoryManagerDuckDB(AbstractHistoryManager):
             ch_in_db.answers.append(answer)
             chat_answer_item_list.append(answer)
 
-        timestamp_now = datetime.now()
+        timestamp_now = time_utils.current_datetime()
         ch_in_db.updated_at = timestamp_now
 
         for query_item in ch_in_db.queries:
@@ -436,7 +435,7 @@ class HistoryManagerDuckDB(AbstractHistoryManager):
     def add_ch_entry(self, ch_create: CHCreate) -> ChatHistory:
         """Add a new chat history entry."""
         chat_id = str(uuid.uuid4())
-        current_time = datetime.now()
+        current_time = time_utils.current_datetime()
 
         chat_dict = ch_create.model_dump()
         chat_dict.update(
@@ -537,7 +536,7 @@ class HistoryManagerDuckDB(AbstractHistoryManager):
         for answer_item in ch_in_db.answers:
             if answer_item.query_id == query_id:
                 ch_in_db.answers.remove(answer_item)
-        ch_in_db.updated_at = datetime.now()
+        ch_in_db.updated_at = time_utils.current_datetime()
         query_dict = self._chat_history_to_dict(ch_in_db)
         column_list = [
             k
@@ -732,7 +731,7 @@ class HistoryManagerDuckDB(AbstractHistoryManager):
                 # tmp solution since we do not want to delete the old answer
                 answer.answer_score = -2
                 answer.query_id = "-" + answer.query_id + "-"
-                answer.updated_at = datetime.now()
+                answer.updated_at = time_utils.current_datetime()
                 updated = True
                 break
 
@@ -881,7 +880,7 @@ class HistoryManagerDuckDB(AbstractHistoryManager):
             logger().info("No update needed for chat history")
             return self.get_ch_entry(ch_update.creator_id, ch_update.chat_id)
 
-        update_dict[ChatHistory.FIELD_UPDATED_AT] = datetime.now()
+        update_dict[ChatHistory.FIELD_UPDATED_AT] = time_utils.current_datetime()
 
         column_list = [k for k in update_dict.keys()]
         value_list = [v for v in update_dict.values()]
@@ -919,7 +918,7 @@ class HistoryManagerDuckDB(AbstractHistoryManager):
                 # tmp solution since we do not want to delete the old answer
                 answer.answer_score = -2
                 answer.query_id = "-" + answer.query_id + "-"
-                answer.updated_at = datetime.now()
+                answer.updated_at = time_utils.current_datetime()
                 new_answer = ChatAnswerItem.from_answer_create(new_answer)
                 chat.answers.append(new_answer)
                 updated = True

--- a/src/leettools/chat/schemas/chat_history.py
+++ b/src/leettools/chat/schemas/chat_history.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
+from leettools.common.utils import time_utils
 from leettools.common.utils.obj_utils import add_fieldname_constants, assign_properties
 from leettools.core.consts.article_type import ArticleType
 from leettools.core.schemas.chat_query_item import ChatQueryItem
@@ -89,7 +90,7 @@ class CHInDB(CHInDBBase):
 
     @classmethod
     def from_ch_create(CHInDB, ch_create: CHCreate) -> "CHInDB":
-        ct = datetime.now()
+        ct = time_utils.current_datetime()
         ch = CHInDB(
             name=ch_create.name,
             org_id=ch_create.org_id,

--- a/src/leettools/cli/doc/doc_list.py
+++ b/src/leettools/cli/doc/doc_list.py
@@ -44,6 +44,8 @@ def list(
     org_name: Optional[str] = None,
     username: Optional[str] = None,
     docsource_uuid: Optional[str] = None,
+    json_output: Optional[bool] = False,
+    indent: Optional[int] = 2,
     **kwargs,
 ) -> None:
     from leettools.context_manager import ContextManager
@@ -94,17 +96,21 @@ def list(
             if doc_original_uri is None:
                 doc_original_uri = document.doc_uri
 
-            click.echo(
-                f"{document.docsink_uuid:<{uid_width}}"
-                f"{document.document_uuid:<{uid_width}}"
-                f"{doc_original_uri}"
-            )
+            if json_output:
+                click.echo(document.model_dump_json(indent=indent))
+            else:
+                click.echo(
+                    f"{document.docsink_uuid:<{uid_width}}"
+                    f"{document.document_uuid:<{uid_width}}"
+                    f"{doc_original_uri}"
+                )
 
-    click.echo(
-        f"{'DocSink UUID':<{uid_width}}"
-        f"{'Document UUID':<{uid_width}}"
-        f"Original URI"
-    )
+    if not json_output:
+        click.echo(
+            f"{'DocSink UUID':<{uid_width}}"
+            f"{'Document UUID':<{uid_width}}"
+            f"Original URI"
+        )
     if docsource_uuid is not None:
         docsource = docsource_store.get_docsource(org, kb, docsource_uuid)
         traverse_docsource()

--- a/src/leettools/cli/kb/kb_add_local_dir.py
+++ b/src/leettools/cli/kb/kb_add_local_dir.py
@@ -131,6 +131,7 @@ def add_local_dir(
         pipeline_utils.process_docsource_manual(
             org=org,
             kb=kb,
+            user=user,
             docsource=docsource,
             context=context,
             display_logger=display_logger,

--- a/src/leettools/cli/kb/kb_add_search.py
+++ b/src/leettools/cli/kb/kb_add_search.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import click
 
 from leettools.cli.cli_utils import setup_org_kb_user
@@ -86,6 +88,8 @@ def add_search(
     username: str,
     chunk_size: str,
     scheduler_check: bool,
+    json_output: Optional[bool] = False,
+    indent: Optional[int] = 2,
     **kwargs,
 ) -> None:
     from leettools.context_manager import ContextManager
@@ -135,14 +139,15 @@ def add_search(
     )
 
     documents = document_store.get_documents_for_docsource(org, kb, docsource)
-    click.echo("org\tkb\tdocsink_id\tdocument_uuid\tURI")
-    for document in documents:
-        click.echo(
-            f"{org.name}\t{kb.name}"
-            f"\t{document.docsink_uuid}\t{document.document_uuid}"
-            f"\t{document.original_uri}"
-        )
 
-
-if __name__ == "__main__":
-    add_search()
+    if json_output:
+        for document in documents:
+            click.echo(document.model_dump_json(indent=indent))
+    else:
+        click.echo("org\tkb\tdocsink_id\tdocument_uuid\tURI")
+        for document in documents:
+            click.echo(
+                f"{org.name}\t{kb.name}"
+                f"\t{document.docsink_uuid}\t{document.document_uuid}"
+                f"\t{document.original_uri}"
+            )

--- a/src/leettools/cli/kb/kb_add_url.py
+++ b/src/leettools/cli/kb/kb_add_url.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import click
 
 from leettools.cli.cli_utils import setup_org_kb_user
@@ -66,6 +68,8 @@ def add_url(
     username: str,
     chunk_size: str,
     scheduler_check: bool,
+    json_output: Optional[bool] = False,
+    indent: Optional[int] = 2,
     **kwargs,
 ) -> None:
     from leettools.context_manager import Context, ContextManager
@@ -106,6 +110,7 @@ def add_url(
         pipeline_utils.process_docsource_manual(
             org=org,
             kb=kb,
+            user=user,
             docsource=docsource,
             context=context,
             display_logger=logger(),
@@ -121,10 +126,13 @@ def add_url(
         return
 
     document = documents[0]
-    click.echo(
-        f"org:\t{org.name}\n"
-        f"kb:\t{kb.name}\n"
-        f"docource_id:\t{docsource.docsource_uuid}\n"
-        f"docsink_id:\t{document.docsink_uuid}\n"
-        f"document_uuid:\t{document.document_uuid}"
-    )
+    if json_output:
+        click.echo(document.model_dump_json(indent=indent))
+    else:
+        click.echo(
+            f"org:\t{org.name}\n"
+            f"kb:\t{kb.name}\n"
+            f"docource_id:\t{docsource.docsource_uuid}\n"
+            f"docsink_id:\t{document.docsink_uuid}\n"
+            f"document_uuid:\t{document.document_uuid}"
+        )

--- a/src/leettools/cli/kb/kb_add_url_list.py
+++ b/src/leettools/cli/kb/kb_add_url_list.py
@@ -125,6 +125,7 @@ def add_url_list(
             pipeline_utils.process_docsource_manual(
                 org=org,
                 kb=kb,
+                user=user,
                 docsource=docsource,
                 context=context,
                 display_logger=logger(),

--- a/src/leettools/cli/kb/kb_cli.py
+++ b/src/leettools/cli/kb/kb_cli.py
@@ -4,7 +4,7 @@ from .kb_add_local_dir import add_local_dir
 from .kb_add_search import add_search
 from .kb_add_url import add_url
 from .kb_add_url_list import add_url_list
-from .kb_crud import create
+from .kb_create import create
 from .kb_list import list
 from .kb_list_db import list_db
 

--- a/src/leettools/cli/kb/kb_create.py
+++ b/src/leettools/cli/kb/kb_create.py
@@ -1,0 +1,79 @@
+from typing import Optional
+
+import click
+
+from leettools.cli.cli_utils import setup_org_kb_user
+from leettools.cli.options_common import common_options
+from leettools.context_manager import ContextManager
+
+
+@click.command(help="Create a new KB.")
+@click.option(
+    "--org",
+    "org_name",
+    default=None,
+    required=False,
+    help="The org to check.",
+)
+@click.option(
+    "-k",
+    "--kb",
+    "kb_name",
+    required=True,
+    help="The knowledgebase name to create.",
+)
+@click.option(
+    "-u",
+    "--user",
+    "username",
+    default=None,
+    required=False,
+    help="The user to use, default the admin user.",
+)
+@click.option(
+    "--schedule",
+    "schedule",
+    is_flag=True,
+    help="Add the KB to the scheduler.",
+)
+@common_options
+def create(
+    org_name: str,
+    kb_name: str,
+    username: str,
+    schedule: bool,
+    json_output: Optional[bool] = False,
+    indent: Optional[int] = 2,
+    **kwargs,
+) -> None:
+    """
+    Create a new KB.
+
+    If no org_name is specified, we will use the default org.
+    If org_name is specified but not found, we will raise an EntityNotFoundException.
+
+    If kb_name already exists, we will show the existing kb info.
+
+    If username is not specified, we will use the default admin user.
+    If username is specified but not found, we will raise an EntityNotFoundException.
+
+    If schedule is False, we will create a new adhoc kb. In this case, we will create the
+    new kb with the kb_name and set it to auto_schedule=False, which means that the kb
+    is excluded from the scheduler. Otherwise the kb will be added to the scheduler.
+    """
+
+    context = ContextManager().get_context()
+    context.is_svc = False
+    context.name = "kb_create"
+
+    if schedule:
+        adhoc_kb = False
+    else:
+        adhoc_kb = True
+
+    org, kb, user = setup_org_kb_user(context, org_name, kb_name, username, adhoc_kb)
+
+    if json_output:
+        click.echo(kb.model_dump_json(indent=indent))
+    else:
+        click.echo(kb)

--- a/src/leettools/common/duckdb/duckdb_client.py
+++ b/src/leettools/common/duckdb/duckdb_client.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pathlib import Path
 from threading import Lock
 from typing import Any, Dict, List, Optional
@@ -70,7 +71,10 @@ class DuckDBClient(metaclass=SingletonMetaDuckDB):
                 ["(" + ",".join(["?"] * len(column_list)) + ")"] * len(values)
             )
             # Flatten the list of values for the executemany function
-            flattened_values = [item for sublist in values for item in sublist]
+            flattened_values: List[Any] = []
+            for sublist in values:
+                for item in sublist:
+                    flattened_values.append(item)
             insert_sql = f"""
                 INSERT INTO {table_name} ({",".join(column_list)})
                 VALUES {placeholders}
@@ -197,7 +201,8 @@ class DuckDBClient(metaclass=SingletonMetaDuckDB):
             else:
                 results = cursor.execute(sql).fetchall()
             column_names = [desc[0] for desc in cursor.description]
-            return [dict(zip(column_names, row)) for row in results]
+            value = [dict(zip(column_names, row)) for row in results]
+            return value
 
     def fetch_all_from_table(
         self,
@@ -227,7 +232,8 @@ class DuckDBClient(metaclass=SingletonMetaDuckDB):
                     results = cursor.execute(select_sql).fetchall()
 
             column_names = [desc[0] for desc in cursor.description]
-            return [dict(zip(column_names, row)) for row in results]
+            value = [dict(zip(column_names, row)) for row in results]
+            return value
 
     def fetch_one_from_table(
         self,
@@ -257,7 +263,8 @@ class DuckDBClient(metaclass=SingletonMetaDuckDB):
                     result = cursor.execute(select_sql).fetchone()
 
             column_names = [desc[0] for desc in cursor.description]
-            return dict(zip(column_names, result)) if result else None
+            value = dict(zip(column_names, result)) if result else None
+            return value
 
     def fetch_sequence_current_value(self, sequence_name: str) -> int:
         with self.conn.cursor() as cursor:

--- a/src/leettools/common/duckdb/duckdb_schema_utils.py
+++ b/src/leettools/common/duckdb/duckdb_schema_utils.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Union, get_args, get_origin
 from pydantic import BaseModel, Field
 
 from leettools.common.logging import logger
+from leettools.common.utils import time_utils
 from leettools.common.utils.obj_utils import TypeVar_BaseModel
 
 
@@ -116,7 +117,7 @@ def duckdb_data_to_pydantic_obj(
                 data[key] = bool(value)
             elif "datetime" in str(field_type).lower():
                 if type(value) is str:
-                    data[key] = datetime.fromisoformat(value)
+                    data[key] = time_utils.datetime_from_timestamp_in_ms()
                 elif type(value) is datetime:
                     data[key] = value
                 else:

--- a/src/leettools/common/temp_setup.py
+++ b/src/leettools/common/temp_setup.py
@@ -6,6 +6,7 @@ from typing import Optional, Tuple
 
 from leettools.chat.history_manager import _HMInstances
 from leettools.common.logging import logger
+from leettools.common.utils import file_utils, time_utils
 from leettools.core.consts.docsource_type import DocSourceType
 from leettools.core.schemas.chat_query_item import ChatQueryItem
 from leettools.core.schemas.docsource import DocSource, DocSourceCreate
@@ -226,7 +227,7 @@ class TempSetup:
                 target_chat_query_item=ChatQueryItem(
                     query_content="dummy query",
                     query_id="dummy query id",
-                    created_at=datetime.now(),
+                    created_at=time_utils.current_datetime(),
                 ),
             )
             pipeline_utils.run_adhoc_pipeline_for_docsinks(

--- a/src/leettools/common/utils/file_utils.py
+++ b/src/leettools/common/utils/file_utils.py
@@ -11,6 +11,7 @@ from urllib.request import url2pathname
 
 from leettools.common import exceptions
 from leettools.common.exceptions import UnexpectedCaseException, UnexpectedIOException
+from leettools.common.utils import time_utils
 
 # Define a dictionary for other replacements
 replacements = {
@@ -193,7 +194,7 @@ def readable_timestamp() -> str:
     Returns:
         Formatted datetime string ('YYYY-MM-DD HH:MM:SS')
     """
-    now = datetime.now()
+    now = time_utils.current_datetime()
     timestamp = now.strftime("%Y-%m-%d %H:%M:%S")
     return timestamp
 
@@ -209,7 +210,7 @@ def filename_timestamp(now: Optional[datetime] = None) -> str:
     -   Formatted datetime string ("%Y-%m-%d-%H-%M-%S-%f")
     """
     if now is None:
-        now = datetime.now()
+        now = time_utils.current_datetime()
     # generate a timestamp up to milliseconds that can be used in a filename
     timestamp = now.strftime("%Y-%m-%d-%H-%M-%S-%f")
     return timestamp

--- a/src/leettools/common/utils/time_utils.py
+++ b/src/leettools/common/utils/time_utils.py
@@ -1,10 +1,23 @@
 from datetime import datetime
 
 
+def current_datetime() -> datetime:
+    return datetime.now()
+
+
 def cur_timestamp_in_ms() -> int:
     ct = datetime.now()
     timestamp_in_ms = int(ct.timestamp() * 1000)
     return timestamp_in_ms
+
+
+def enforce_timezone(dt: datetime) -> datetime:
+    new_dt = dt.replace(tzinfo=None)
+    return new_dt
+
+
+def datetime_from_timestamp_in_ms(timestamp_in_ms: int) -> datetime:
+    return datetime.fromtimestamp(timestamp_in_ms / 1000)
 
 
 def random_str(length: int = 8) -> str:

--- a/src/leettools/core/knowledgebase/_impl/duckdb/kb_manager_duckdb.py
+++ b/src/leettools/core/knowledgebase/_impl/duckdb/kb_manager_duckdb.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional
 from leettools.common import exceptions
 from leettools.common.duckdb.duckdb_client import DuckDBClient
 from leettools.common.logging import logger
+from leettools.common.utils import time_utils
 from leettools.core.consts.segment_embedder_type import SegmentEmbedderType
 from leettools.core.knowledgebase._impl.duckdb.kb_duckdb_schema import KBDuckDBSchema
 from leettools.core.knowledgebase.kb_manager import AbstractKBManager
@@ -201,8 +202,8 @@ class KBManagerDuckDB(AbstractKBManager):
 
         table_name = self._get_table_name(org)
         kb_delete = kb_in_db.model_copy()
-        kb_delete.name = kb_name + "_deleted_" + str(datetime.now())
-        kb_delete.updated_at = datetime.now()
+        kb_delete.name = kb_name + "_deleted_" + str(time_utils.current_datetime())
+        kb_delete.updated_at = time_utils.current_datetime()
         kb_delete.is_deleted = True
 
         kb_dict = self._kb_to_dict(kb_delete)
@@ -325,7 +326,7 @@ class KBManagerDuckDB(AbstractKBManager):
             if k != KnowledgeBase.FIELD_KB_ID and k != KBUpdate.FIELD_NEW_NAME
         ]
         column_list = column_list + [KnowledgeBase.FIELD_UPDATED_AT]
-        value_list = value_list + [datetime.now()]
+        value_list = value_list + [time_utils.current_datetime()]
 
         where_clause = f"WHERE {KnowledgeBase.FIELD_KB_ID} = ?"
         value_list = value_list + [kb_in_db.kb_id]
@@ -348,7 +349,7 @@ class KBManagerDuckDB(AbstractKBManager):
 
         table_name = self._get_table_name(org)
         column_list = [KnowledgeBase.FIELD_UPDATED_AT]
-        value_list = [datetime.now()]
+        value_list = [time_utils.current_datetime()]
         where_clause = f"WHERE {KnowledgeBase.FIELD_KB_ID} = ?"
         value_list = value_list + [kb_in_db.kb_id]
         self.duckdb_client.update_table(

--- a/src/leettools/core/knowledgebase/kb_manager.py
+++ b/src/leettools/core/knowledgebase/kb_manager.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import ClassVar, List, Optional
 
+from leettools.common.utils import time_utils
 from leettools.core.config.performance_configurable import PerformanceConfigurable
 from leettools.core.schemas.knowledgebase import KBCreate, KBUpdate, KnowledgeBase
 from leettools.core.schemas.organization import Org
@@ -10,7 +11,7 @@ from leettools.settings import SystemSettings
 
 def get_kb_name_from_query(query: str) -> str:
     # create a timestamp in the format of "YYYYMMDD_HHMMSS"
-    now = datetime.now()
+    now = time_utils.current_datetime()
     timestamp = now.strftime("%Y%m%d_%H%M%S")
 
     # get the first two words of the query

--- a/src/leettools/core/org/_impl/duckdb/org_manager_duckdb.py
+++ b/src/leettools/core/org/_impl/duckdb/org_manager_duckdb.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 
 from leettools.common.duckdb.duckdb_client import DuckDBClient
 from leettools.common.exceptions import EntityNotFoundException
+from leettools.common.utils import time_utils
 from leettools.core.org._impl.duckdb.org_duckdb_schema import OrgDuckDBSchema
 from leettools.core.org.org_manager import AbstractOrgManager
 from leettools.core.schemas.organization import Org, OrgCreate, OrgInDB, OrgUpdate
@@ -118,7 +119,7 @@ class OrgManagerDuckDB(AbstractOrgManager):
 
         org_id = org_update_dict.pop(Org.FIELD_ORG_ID)
         column_list = list(org_update_dict.keys()) + [Org.FIELD_UPDATED_AT]
-        value_list = list(org_update_dict.values()) + [datetime.now()]
+        value_list = list(org_update_dict.values()) + [time_utils.current_datetime()]
         where_clause = f"WHERE {Org.FIELD_ORG_ID} = ?"
         value_list = value_list + [org_id]
         self.duckdb_client.update_table(

--- a/src/leettools/core/repo/_impl/duckdb/docsink_store_duckdb.py
+++ b/src/leettools/core/repo/_impl/duckdb/docsink_store_duckdb.py
@@ -5,6 +5,7 @@ from typing import Any, List, Optional
 from leettools.common import exceptions
 from leettools.common.duckdb.duckdb_client import DuckDBClient
 from leettools.common.logging import logger
+from leettools.common.utils import time_utils
 from leettools.core.consts.docsink_status import DocSinkStatus
 from leettools.core.repo._impl.duckdb.docsink_store_duckdb_schema import (
     DocsinkDuckDBSchema,
@@ -210,7 +211,7 @@ class DocsinkStoreDuckDB(AbstractDocsinkStore):
                 )
             else:
                 using_existing.docsource_uuids.append(docsource_uuid)
-            using_existing.updated_at = datetime.now()
+            using_existing.updated_at = time_utils.current_datetime()
             update_docsink = self.update_docsink(org, kb, using_existing)
             return update_docsink
 
@@ -220,7 +221,7 @@ class DocsinkStoreDuckDB(AbstractDocsinkStore):
     def delete_docsink(self, org: Org, kb: KnowledgeBase, docsink: DocSink) -> bool:
         table_name = self._get_table_name(org, kb)
         column_list = [DocSink.FIELD_IS_DELETED, DocSink.FIELD_UPDATED_AT]
-        value_list = [True, datetime.now()]
+        value_list = [True, time_utils.current_datetime()]
         where_clause = f"WHERE {DocSink.FIELD_DOCSINK_UUID} = ?"
         value_list = value_list + [docsink.docsink_uuid]
         self.duckdb_client.update_table(

--- a/src/leettools/core/repo/_impl/duckdb/docsource_store_duckdb.py
+++ b/src/leettools/core/repo/_impl/duckdb/docsource_store_duckdb.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 from leettools.common import exceptions
 from leettools.common.duckdb.duckdb_client import DuckDBClient
 from leettools.common.logging import logger
+from leettools.common.utils import time_utils
 from leettools.core.consts.docsource_status import DocSourceStatus
 from leettools.core.repo._impl.duckdb.docsource_store_duckdb_schema import (
     DocSourceDuckDBSchema,
@@ -138,7 +139,7 @@ class DocsourceStoreDuckDB(AbstractDocsourceStore):
             DocSource.FIELD_DOCSOURCE_STATUS,
             DocSource.FIELD_UPDATED_AT,
         ]
-        value_list = [True, DocSourceStatus.ABORTED, datetime.now()]
+        value_list = [True, DocSourceStatus.ABORTED, time_utils.current_datetime()]
         where_clause = (
             f"WHERE {DocSource.FIELD_DOCSOURCE_UUID} = '{docsource.docsource_uuid}'"
         )

--- a/src/leettools/core/repo/_impl/duckdb/document_store_duckdb.py
+++ b/src/leettools/core/repo/_impl/duckdb/document_store_duckdb.py
@@ -1,10 +1,10 @@
 import json
 import uuid
-from datetime import datetime
 from typing import List, Optional
 
 from leettools.common.duckdb.duckdb_client import DuckDBClient
 from leettools.common.logging import logger
+from leettools.common.utils import time_utils
 from leettools.core.consts.segment_embedder_type import SegmentEmbedderType
 from leettools.core.repo._impl.duckdb.document_store_duckdb_schema import (
     DocumentDuckDBSchema,
@@ -207,7 +207,7 @@ class DocumentStoreDuckDB(AbstractDocumentStore):
             return False
 
         # Update document status
-        update_time = datetime.now()
+        update_time = time_utils.current_datetime()
         column_list = [Document.FIELD_IS_DELETED, Document.FIELD_UPDATED_AT]
         where_clause = f"WHERE {Document.FIELD_DOCUMENT_UUID} = ?"
         value_list = [True, update_time, document.document_uuid]

--- a/src/leettools/core/schemas/chat_query_item.py
+++ b/src/leettools/core/schemas/chat_query_item.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 
 from leettools.common import exceptions
 from leettools.common.logging import EventLogger, logger
-from leettools.common.utils import obj_utils
+from leettools.common.utils import obj_utils, time_utils
 from leettools.core.schemas.chat_query_options import ChatQueryOptions
 from leettools.core.strategy.schemas.strategy import Strategy, StrategyBase
 from leettools.core.strategy.schemas.strategy_status import StrategyStatus
@@ -15,6 +15,9 @@ from leettools.core.strategy.strategy_store import AbstractStrategyStore
 """
 See [README](./README.md) about the usage of different pydantic models.
 """
+
+DUMMY_QUERY_ID = "dummy_query_id"
+DUMMY_QUERY_CONTENT = "dummy_query_content"
 
 
 class ChatQueryItemCreate(BaseModel):
@@ -57,7 +60,7 @@ class ChatQueryItem(ChatQueryItemCreate):
 
     @classmethod
     def from_query_create(cls, query_create: ChatQueryItemCreate) -> "ChatQueryItem":
-        ct = datetime.now()
+        ct = time_utils.current_datetime()
         chat_query_item = cls(
             chat_id=query_create.chat_id,
             query_id=str(uuid.uuid4()),

--- a/src/leettools/core/schemas/chat_query_result.py
+++ b/src/leettools/core/schemas/chat_query_result.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
-from leettools.common.utils import obj_utils
+from leettools.common.utils import obj_utils, time_utils
 from leettools.core.consts.article_type import ArticleType
 from leettools.core.consts.display_type import DisplayType
 from leettools.flow.schemas.article import ArticleSectionPlan
@@ -85,7 +85,7 @@ class ChatAnswerItem(ChatAnswerItemCreate):
     def from_answer_create(
         ChatAnswerItem, answer_create: ChatAnswerItemCreate
     ) -> "ChatAnswerItem":
-        ct = datetime.now()
+        ct = time_utils.current_datetime()
         answer = ChatAnswerItem(
             chat_id=answer_create.chat_id,
             query_id=answer_create.query_id,

--- a/src/leettools/core/schemas/docsink.py
+++ b/src/leettools/core/schemas/docsink.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
+from leettools.common.utils import time_utils
 from leettools.common.utils.obj_utils import add_fieldname_constants, assign_properties
 from leettools.core.consts.docsink_status import DocSinkStatus
 from leettools.core.schemas.docsource import DocSource
@@ -57,7 +58,7 @@ class DocSinkInDB(DocSinkInDBBase):
 
     @classmethod
     def from_docsink_create(cls, docsink_create: DocSinkCreate) -> "DocSinkInDB":
-        ct = datetime.now()
+        ct = time_utils.current_datetime()
         docsource = docsink_create.docsource
         docsink_in_store = cls(
             docsink_uuid="",
@@ -85,7 +86,7 @@ class DocSinkInDB(DocSinkInDBBase):
             original_doc_uri=docsink_update.original_doc_uri,
             is_deleted=docsink_update.is_deleted,
             docsink_status=docsink_update.docsink_status,
-            updated_at=datetime.now(),
+            updated_at=time_utils.current_datetime(),
         )
         assign_properties(docsink_update, docsink_in_store)
         return docsink_in_store

--- a/src/leettools/core/schemas/docsource.py
+++ b/src/leettools/core/schemas/docsource.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
+from leettools.common.utils import time_utils
 from leettools.common.utils.obj_utils import add_fieldname_constants, assign_properties
 from leettools.core.consts.docsource_status import DocSourceStatus
 from leettools.core.consts.docsource_type import DocSourceType
@@ -115,7 +116,7 @@ class DocSourceInDB(DocSourceInDBBase):
     def from_docsource_create(
         DocSourceInDB, docsource_create: DocSourceCreate
     ) -> "DocSourceInDB":
-        ct = datetime.now()
+        ct = time_utils.current_datetime()
 
         docsource_in_store = DocSourceInDB(
             # caller needs to update uuid later document is
@@ -148,7 +149,7 @@ class DocSourceInDB(DocSourceInDBBase):
             kb_id=docsource_update.kb_id,
             is_deleted=docsource_update.is_deleted,
             docsource_status=docsource_update.docsource_status,
-            updated_at=datetime.now(),
+            updated_at=time_utils.current_datetime(),
         )
         assign_properties(docsource_update, docsource_in_store)
         return docsource_in_store

--- a/src/leettools/core/schemas/document.py
+++ b/src/leettools/core/schemas/document.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
+from leettools.common.utils import time_utils
 from leettools.common.utils.obj_utils import add_fieldname_constants, assign_properties
 from leettools.core.consts.document_status import DocumentStatus
 from leettools.core.schemas.docsink import DocSink
@@ -83,7 +84,7 @@ class DocumentInDB(DocumentInDBBase):
     def from_document_create(
         DocumentInDB, document_create: DocumentCreate
     ) -> "DocumentInDB":
-        ct = datetime.now()
+        ct = time_utils.current_datetime()
         docsink = document_create.docsink
         document_in_store = DocumentInDB(
             # caller needs to update uuid later document is

--- a/src/leettools/core/schemas/knowledgebase.py
+++ b/src/leettools/core/schemas/knowledgebase.py
@@ -7,6 +7,7 @@ from typing import Any, ClassVar, Dict, List, Optional
 from pydantic import BaseModel, Field
 
 from leettools.common import exceptions
+from leettools.common.utils import time_utils
 from leettools.common.utils.obj_utils import add_fieldname_constants, assign_properties
 from leettools.core.config.performance_configurable import PerfBaseModel
 from leettools.core.consts.segment_embedder_type import SegmentEmbedderType
@@ -111,7 +112,7 @@ class KBInDB(KBInDBBase):
 
     @classmethod
     def from_kb_create(KBInDB, kb_create: KBCreate) -> "KBInDB":
-        ct = datetime.now()
+        ct = time_utils.current_datetime()
         if kb_create.user_uuid is not None:
             if kb_create.owner_id is None:
                 kb_create.owner_id = kb_create.user_uuid

--- a/src/leettools/core/schemas/organization.py
+++ b/src/leettools/core/schemas/organization.py
@@ -5,6 +5,7 @@ from typing import Any, ClassVar, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
+from leettools.common.utils import time_utils
 from leettools.common.utils.obj_utils import add_fieldname_constants, assign_properties
 from leettools.core.consts.org_status import OrgStatus
 
@@ -45,7 +46,7 @@ class OrgInDB(OrgInDBBase):
 
     @classmethod
     def from_org_create(OrgInDB, org_create: OrgCreate) -> "OrgInDB":
-        ct = datetime.now()
+        ct = time_utils.current_datetime()
         org = OrgInDB(
             name=org_create.name,
             description=org_create.description,

--- a/src/leettools/core/schemas/segment.py
+++ b/src/leettools/core/schemas/segment.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
+from leettools.common.utils import time_utils
 from leettools.common.utils.obj_utils import add_fieldname_constants, assign_properties
 
 """
@@ -103,7 +104,7 @@ class SegmentInDB(SegmentInDBBase):
     def from_segment_create(
         SegmentInDB, segment_create: SegmentCreate
     ) -> "SegmentInDB":
-        ct = datetime.now()
+        ct = time_utils.current_datetime()
         if segment_create.created_timestamp_in_ms is None:
             segment_create.created_timestamp_in_ms = int(ct.timestamp() * 1000)
         segment_in_db = SegmentInDB(
@@ -145,7 +146,7 @@ class SegmentInDB(SegmentInDBBase):
             start_offset=segment_update.start_offset,
             end_offset=segment_update.end_offset,
             embeddings=segment_update.embeddings,
-            updated_at=datetime.now(),
+            updated_at=time_utils.current_datetime(),
         )
         assign_properties(segment_in_db, segment_update)
         return segment_in_db

--- a/src/leettools/core/schemas/user.py
+++ b/src/leettools/core/schemas/user.py
@@ -5,7 +5,7 @@ from typing import Any, ClassVar, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
-from leettools.common.utils import auth_utils
+from leettools.common.utils import auth_utils, time_utils
 from leettools.common.utils.obj_utils import add_fieldname_constants, assign_properties
 from leettools.core.consts.accouting import INIT_BALANCE
 
@@ -50,7 +50,7 @@ class UserInDB(UserCreate):
 
     @classmethod
     def from_user_create(UserInDB, user_create: UserCreate) -> "UserInDB":
-        ct = datetime.now()
+        ct = time_utils.current_datetime()
         user_in_db = UserInDB(
             username=user_create.username,
             user_uuid="",

--- a/src/leettools/core/strategy/_impl/duckdb/intention_store_duckdb.py
+++ b/src/leettools/core/strategy/_impl/duckdb/intention_store_duckdb.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 
 from leettools.common.duckdb.duckdb_client import DuckDBClient
 from leettools.common.exceptions import EntityExistsException, EntityNotFoundException
+from leettools.common.utils import time_utils
 from leettools.core.strategy._impl.duckdb.intention_store_ducksb_schema import (
     IntentionDuckDBSchema,
 )
@@ -85,7 +86,7 @@ class IntentionStoreDuckDB(AbstractIntentionStore):
         intention_dict = self._intention_to_dict(intention_create)
         if intention_create.display_name is None:
             intention_dict[Intention.FIELD_DISPLAY_NAME] = intention_create.intention
-        intention_dict[Intention.FIELD_CREATED_AT] = datetime.now()
+        intention_dict[Intention.FIELD_CREATED_AT] = time_utils.current_datetime()
         intention_dict[Intention.FIELD_UPDATED_AT] = intention_dict[
             Intention.FIELD_CREATED_AT
         ]
@@ -109,7 +110,7 @@ class IntentionStoreDuckDB(AbstractIntentionStore):
             )
 
         intention_dict = self._intention_to_dict(intention_update)
-        intention_dict[Intention.FIELD_UPDATED_AT] = datetime.now()
+        intention_dict[Intention.FIELD_UPDATED_AT] = time_utils.current_datetime()
         table_name = self._get_table_name()
         column_list = list(intention_dict.keys())
         value_list = list(intention_dict.values())

--- a/src/leettools/core/strategy/_impl/duckdb/prompt_store_duckdb.py
+++ b/src/leettools/core/strategy/_impl/duckdb/prompt_store_duckdb.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 from leettools.common.duckdb.duckdb_client import DuckDBClient
 from leettools.common.exceptions import EntityNotFoundException
 from leettools.common.logging import logger
+from leettools.common.utils import time_utils
 from leettools.core.strategy._impl.duckdb.prompt_store_ducksb_schema import (
     PromptDuckDBSchema,
 )
@@ -81,7 +82,7 @@ class PromptStoreDuckDB(AbstractPromptStore):
             )
             return self._dict_to_prompt(result)
 
-        current_time = datetime.now()
+        current_time = time_utils.current_datetime()
         prompt_dict = self._prompt_to_dict(prompt_create)
         prompt_id = str(uuid.uuid4())
         prompt_dict[Prompt.FIELD_PROMPT_ID] = prompt_id
@@ -120,7 +121,7 @@ class PromptStoreDuckDB(AbstractPromptStore):
         """Set the status of a prompt in the store."""
         table_name = self._get_table_name()
         column_list = [Prompt.FIELD_PROMPT_STATUS, Prompt.FIELD_UPDATED_AT]
-        value_list = [status, datetime.now()]
+        value_list = [status, time_utils.current_datetime()]
         where_clause = f"WHERE {Prompt.FIELD_PROMPT_ID} = ?"
         value_list = value_list + [prompt_id]
         self.duckdb_client.update_table(

--- a/src/leettools/core/strategy/_impl/duckdb/strategy_store_duckdb.py
+++ b/src/leettools/core/strategy/_impl/duckdb/strategy_store_duckdb.py
@@ -11,6 +11,7 @@ from leettools.common.exceptions import (
     UnexpectedOperationFailureException,
 )
 from leettools.common.logging import logger
+from leettools.common.utils import time_utils
 from leettools.common.utils.template_eval import find_template_variables
 from leettools.core.schemas.user import User
 from leettools.core.strategy._impl.duckdb.strategy_store_ducksb_schema import (
@@ -91,7 +92,7 @@ class StrategyStoreDuckDB(AbstractStrategyStore):
         """
         table_name = self._get_table_name()
         column_list = [Strategy.FIELD_STRATEGY_STATUS, Strategy.FIELD_UPDATED_AT]
-        value_list = [StrategyStatus.ARCHIVED.value, datetime.now()]
+        value_list = [StrategyStatus.ARCHIVED.value, time_utils.current_datetime()]
         where_clause = f"WHERE {Strategy.FIELD_STRATEGY_ID} = '{strategy.strategy_id}'"
         self.duckdb_client.update_table(
             table_name=table_name,
@@ -267,7 +268,7 @@ class StrategyStoreDuckDB(AbstractStrategyStore):
         strategy_dict[Strategy.FIELD_STRATEGY_ID] = str(uuid.uuid4())
         strategy_dict[Strategy.FIELD_STRATEGY_STATUS] = StrategyStatus.ACTIVE.value
         strategy_dict[Strategy.FIELD_STRATEGY_HASH] = strategy_hash
-        current_time = datetime.now()
+        current_time = time_utils.current_datetime()
         strategy_dict[Strategy.FIELD_STRATEGY_VERSION] = current_time.strftime(
             "%Y%m%d-%H%M%S"
         )
@@ -473,7 +474,7 @@ class StrategyStoreDuckDB(AbstractStrategyStore):
     ) -> Strategy:
         table_name = self._get_table_name()
         column_list = [Strategy.FIELD_STRATEGY_STATUS, Strategy.FIELD_UPDATED_AT]
-        value_list = [status.value, datetime.now()]
+        value_list = [status.value, time_utils.current_datetime()]
         where_clause = f"WHERE {Strategy.FIELD_STRATEGY_ID} = '{strategy_id}'"
         self.duckdb_client.update_table(
             table_name=table_name,

--- a/src/leettools/core/user/_impl/duckdb/user_settings_store_duckdb.py
+++ b/src/leettools/core/user/_impl/duckdb/user_settings_store_duckdb.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Any, Dict, List
 
 from leettools.common.duckdb.duckdb_client import DuckDBClient
+from leettools.common.utils import time_utils
 from leettools.core.schemas.api_provider_config import (
     APIEndpointInfo,
     APIProviderConfig,
@@ -105,7 +106,7 @@ class UserSettingsStoreDuckDB(AbstractUserSettingsStore):
         user_settings_dict = self._user_settings_to_dict(user_settings_create)
         user_settings_dict[UserSettings.FIELD_USER_SETTINGS_ID] = str(uuid.uuid4())
 
-        current_time = datetime.now()
+        current_time = time_utils.current_datetime()
         user_settings_dict[UserSettings.FIELD_CREATED_AT] = current_time
         user_settings_dict[UserSettings.FIELD_UPDATED_AT] = current_time
 
@@ -120,7 +121,7 @@ class UserSettingsStoreDuckDB(AbstractUserSettingsStore):
         table_name = self._get_user_settings_table_for_user(user_settings.user_uuid)
 
         user_settings_copy = user_settings.model_copy()
-        user_settings_copy.updated_at = datetime.now()
+        user_settings_copy.updated_at = time_utils.current_datetime()
         user_settings_dict = self._user_settings_to_dict(user_settings_copy)
         user_settings_id = user_settings_dict.pop(UserSettings.FIELD_USER_SETTINGS_ID)
         column_list = list(user_settings_dict.keys())

--- a/src/leettools/core/user/_impl/duckdb/user_store_duckdb.py
+++ b/src/leettools/core/user/_impl/duckdb/user_store_duckdb.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 from leettools.common import exceptions
 from leettools.common.duckdb.duckdb_client import DuckDBClient
 from leettools.common.logging import logger
+from leettools.common.utils import time_utils
 from leettools.context_manager import Context
 from leettools.core.schemas.user import User, UserCreate, UserInDB, UserUpdate
 from leettools.core.user._impl.duckdb.user_store_duckdb_schema import UserDuckDBSchema
@@ -173,7 +174,7 @@ class UserStoreDuckDB(AbstractUserStore):
     def update_user(self, user_update: UserUpdate) -> Optional[User]:
         user_uuid = user_update.user_uuid
         update_dict = user_update.model_dump()
-        update_dict[User.FIELD_UPDATED_AT] = datetime.now()
+        update_dict[User.FIELD_UPDATED_AT] = time_utils.current_datetime()
         user_uuid = update_dict.pop(User.FIELD_USER_UUID)
         column_list = list(update_dict.keys())
         where_clause = f"WHERE {User.FIELD_USER_UUID} = ?"

--- a/src/leettools/eds/extract/_impl/duckdb/extract_store_duckdb.py
+++ b/src/leettools/eds/extract/_impl/duckdb/extract_store_duckdb.py
@@ -67,7 +67,7 @@ class ExtractStoreDuckdb(AbstractExtractStore):
                 key_fields=[],  # TODO: add key fields
                 verify_fields=[],
                 item_count=0,
-                created_at=datetime.now(),
+                created_at=time_utils.current_datetime(),
             ),
         )
 

--- a/src/leettools/eds/metadata/_impl/duckdb/kb_metadata_manager_duckdb.py
+++ b/src/leettools/eds/metadata/_impl/duckdb/kb_metadata_manager_duckdb.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional
 import leettools.common.utils.url_utils
 from leettools.common.duckdb.duckdb_client import DuckDBClient
 from leettools.common.logging import get_logger, logger
-from leettools.common.utils import file_utils
+from leettools.common.utils import file_utils, time_utils
 from leettools.context_manager import Context, ContextManager
 from leettools.core.consts.docsource_type import DocSourceType
 from leettools.core.schemas.document import Document
@@ -117,7 +117,7 @@ class KBMetadataManagerDuckDB(AbstractKBMetadataManager):
         kb_metadata = KBMetadata(
             kb_id=kb.kb_id,
             kb_name=kb.name,
-            created_at=datetime.now(),
+            created_at=time_utils.current_datetime(),
             number_of_docsources={src_type: 0 for src_type in DocSourceType},
             number_of_docsinks={src_type: 0 for src_type in DocSourceType},
             number_of_documents={src_type: 0 for src_type in DocSourceType},

--- a/src/leettools/eds/pipeline/split/splitter.py
+++ b/src/leettools/eds/pipeline/split/splitter.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional, Tuple
 from urllib.parse import unquote
 
 from leettools.common.logging import logger
+from leettools.common.utils import time_utils
 from leettools.common.utils.tokenizer import Tokenizer
 from leettools.context_manager import Context
 from leettools.core.consts.return_code import ReturnCode
@@ -222,7 +223,7 @@ class Splitter:
         chunks = chunker.chunk(doc.content)
 
         doc_postion_map: Dict[str, int] = {}
-        epoch_time_ms = int(datetime.now().timestamp() * 1000)
+        epoch_time_ms = time_utils.cur_timestamp_in_ms()
 
         """
         Get the document content for contextual retrieval.

--- a/src/leettools/eds/scheduler/_impl/scheduler_simple.py
+++ b/src/leettools/eds/scheduler/_impl/scheduler_simple.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional, Union
 
 import leettools.common.exceptions as LlmedsException
 from leettools.common.logging import get_logger
+from leettools.common.utils import time_utils
 from leettools.context_manager import Context
 from leettools.core.schemas.docsource import DocSource
 from leettools.core.schemas.knowledgebase import KnowledgeBase
@@ -288,7 +289,7 @@ class SchedulerSimple(AbstractScheduler):
             self.logger.noop("Outside the lock ...")
         else:
             delay_in_seconds = min(max_delay, base_delay * 2**job.retry_count)
-            diff: timedelta = datetime.now() - job.last_failed_at
+            diff: timedelta = time_utils.current_datetime() - job.last_failed_at
             if diff.total_seconds() < delay_in_seconds:
                 # silently put the job back to the cooldown queue
                 self.cooldown_queue.put(job)
@@ -422,7 +423,7 @@ class SchedulerSimple(AbstractScheduler):
             self.logger.debug(
                 f"Adding failed job {job.job_uuid} to the cooldown queue."
             )
-            job.last_failed_at = datetime.now()
+            job.last_failed_at = time_utils.current_datetime()
             if job.retry_count is None:
                 job.retry_count = 1
             else:

--- a/src/leettools/eds/scheduler/_impl/task_scanner_kb.py
+++ b/src/leettools/eds/scheduler/_impl/task_scanner_kb.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional, Set
 
 from leettools.common import exceptions
 from leettools.common.logging import get_logger
+from leettools.common.utils import time_utils
 from leettools.context_manager import Context
 from leettools.core.consts.docsink_status import DocSinkStatus
 from leettools.core.consts.docsource_status import DocSourceStatus
@@ -466,7 +467,7 @@ class TaskScannerKB(AbstractTaskScanner):
 
         new_tasks = []
         orgs = self.org_manager.list_orgs()
-        current_time = datetime.now()
+        current_time = time_utils.current_datetime()
         docsource_retry_range = timedelta(hours=self.docsource_retry_range_in_hours)
 
         for org in orgs:
@@ -571,7 +572,7 @@ class TaskScannerKB(AbstractTaskScanner):
                         # so last_scan_time is not used currently.
                         self.last_scan_time[org.org_id][kb.kb_id][
                             docsource.docsource_uuid
-                        ] = datetime.now()
+                        ] = time_utils.current_datetime()
                     except Exception as e:
                         self.logger.error(
                             f"Error processing docsource for tasks {docsource.uri}: {e}"

--- a/src/leettools/eds/scheduler/schemas/job.py
+++ b/src/leettools/eds/scheduler/schemas/job.py
@@ -6,6 +6,7 @@ from typing import Dict, Optional
 
 from pydantic import BaseModel, Field
 
+from leettools.common.utils import time_utils
 from leettools.common.utils.obj_utils import add_fieldname_constants, assign_properties
 from leettools.eds.scheduler.schemas.job_status import JobStatus
 from leettools.eds.scheduler.schemas.program import ProgramSpec
@@ -66,7 +67,7 @@ class JobInDB(JobInDBBase):
 
     @classmethod
     def from_job_create(JobInDB, job_create: JobCreate) -> "JobInDB":
-        ct = datetime.now()
+        ct = time_utils.current_datetime()
         job_in_db = JobInDB(
             task_uuid=job_create.task_uuid,
             program_spec=job_create.program_spec,
@@ -85,7 +86,7 @@ class JobInDB(JobInDBBase):
             program_spec=job_update.program_spec,
             job_uuid=job_update.job_uuid,
             job_status=job_update.job_status,
-            updated_at=datetime.now(),
+            updated_at=time_utils.current_datetime(),
             progress=job_update.progress,
         )
         assign_properties(job_update, job_in_db)
@@ -106,7 +107,9 @@ class JobInDB(JobInDBBase):
         # make sure the file exists for log streaming
         # append mode will create the file if it does not exist
         with open(self.log_location, "a+") as f:
-            f.write(f"Job log for {job_uuid} created at {datetime.now()}\n")
+            f.write(
+                f"Job log for {job_uuid} created at {time_utils.current_datetime()}\n"
+            )
 
 
 # Properties to return to client

--- a/src/leettools/eds/scheduler/schemas/task.py
+++ b/src/leettools/eds/scheduler/schemas/task.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
 
+from leettools.common.utils import time_utils
 from leettools.common.utils.obj_utils import add_fieldname_constants, assign_properties
 from leettools.eds.scheduler.schemas.program import ProgramSpec
 
@@ -70,7 +71,7 @@ class TaskUpdate(TaskInDBBase):
 class TaskInDB(TaskInDBBase):
     @classmethod
     def from_task_create(TaskInDB, task_create: TaskCreate) -> "TaskInDB":
-        ct = datetime.now()
+        ct = time_utils.current_datetime()
         task_in_db = TaskInDB(
             org_id=task_create.org_id,
             kb_id=task_create.kb_id,
@@ -95,7 +96,7 @@ class TaskInDB(TaskInDBBase):
             program_spec=copy.deepcopy(task_update.program_spec),
             task_uuid=task_update.task_uuid,
             job_status=task_update.task_status,
-            updated_at=datetime.now(),
+            updated_at=time_utils.current_datetime(),
         )
         assign_properties(task_update, task_in_db)
         return task_in_db

--- a/src/leettools/eds/scheduler/task/_impl/duckdb/jobstore_duckdb.py
+++ b/src/leettools/eds/scheduler/task/_impl/duckdb/jobstore_duckdb.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 
 from leettools.common.duckdb.duckdb_client import DuckDBClient
 from leettools.common.exceptions import EntityNotFoundException
+from leettools.common.utils import time_utils
 from leettools.eds.scheduler.schemas.job import Job, JobCreate, JobInDB, JobUpdate
 from leettools.eds.scheduler.schemas.job_status import JobStatus
 from leettools.eds.scheduler.schemas.program import ProgramSpec
@@ -87,7 +88,7 @@ class JobStoreDuckDB(AbstractJobStore):
             raise EntityNotFoundException(entity_name=job_uuid, entity_type="Job")
 
         existing_job.is_deleted = True
-        existing_job.updated_at = datetime.now()
+        existing_job.updated_at = time_utils.current_datetime()
 
         job_dict = self._job_to_dict(existing_job)
         job_uuid = job_dict.pop(Job.FIELD_JOB_UUID)
@@ -200,7 +201,7 @@ class JobStoreDuckDB(AbstractJobStore):
         where_clause = f"WHERE {Job.FIELD_JOB_UUID} = ?"
         value_list = [job_uuid]
         column_list = [Job.FIELD_JOB_STATUS, Job.FIELD_UPDATED_AT]
-        value_list = [job_status, datetime.now()] + value_list
+        value_list = [job_status, time_utils.current_datetime()] + value_list
         self.duckdb_client.update_table(
             table_name=self.table_name,
             column_list=column_list,

--- a/src/leettools/eds/scheduler/task/_impl/duckdb/taskstore_duckdb.py
+++ b/src/leettools/eds/scheduler/task/_impl/duckdb/taskstore_duckdb.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 from leettools.common.duckdb.duckdb_client import DuckDBClient
 from leettools.common.exceptions import EntityNotFoundException, UnexpectedCaseException
 from leettools.common.logging import logger
+from leettools.common.utils import time_utils
 from leettools.core.schemas.docsink import DocSink
 from leettools.core.schemas.docsource import DocSource
 from leettools.core.schemas.document import Document
@@ -85,7 +86,7 @@ class TaskStoreDuckDB(AbstractTaskStore):
             raise EntityNotFoundException(entity_name=task_uuid, entity_type="Task")
 
         task.is_deleted = True
-        task.updated_at = datetime.now()
+        task.updated_at = time_utils.current_datetime()
 
         task_dict = self._task_to_dict(task)
         task_uuid = task_dict.pop(Task.FIELD_TASK_UUID)
@@ -242,7 +243,7 @@ class TaskStoreDuckDB(AbstractTaskStore):
         - The updated task.
         """
         column_list = [Task.FIELD_TASK_STATUS, Task.FIELD_UPDATED_AT]
-        value_list = [job_status, datetime.now()] + [task_uuid]
+        value_list = [job_status, time_utils.current_datetime()] + [task_uuid]
         where_clause = f"WHERE {Task.FIELD_TASK_UUID}=?"
         self.duckdb_client.update_table(
             table_name=self.table_name,

--- a/src/leettools/eds/usage/_impl/duckdb/usage_store_duckdb.py
+++ b/src/leettools/eds/usage/_impl/duckdb/usage_store_duckdb.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import List, Optional
 
 from leettools.common.duckdb.duckdb_client import DuckDBClient
+from leettools.common.utils import time_utils
 from leettools.core.user.user_store import AbstractUserStore
 from leettools.eds.usage._impl.duckdb.usage_store_duckdb_schema import (
     UsageAPICallDuckDBSchema,
@@ -42,7 +43,7 @@ class UsageStoreDuckDB(AbstractUsageStore):
         table_name = self._get_table_name(USAGE_API_CALL)
 
         data_dict = api_usage_create.model_dump()
-        data_dict["created_at"] = datetime.now()
+        data_dict["created_at"] = time_utils.current_datetime()
 
         # convert the usage to LeetToken
         if (

--- a/src/leettools/flow/flows/extract/flow_extract.py
+++ b/src/leettools/flow/flows/extract/flow_extract.py
@@ -7,7 +7,7 @@ from pydantic import ConfigDict
 
 from leettools.common import exceptions
 from leettools.common.logging import EventLogger
-from leettools.common.utils import config_utils
+from leettools.common.utils import config_utils, time_utils
 from leettools.common.utils.dynamic_exec_util import execute_pydantic_snippet
 from leettools.common.utils.obj_utils import TypeVar_BaseModel
 from leettools.common.utils.template_eval import render_template
@@ -273,7 +273,9 @@ Use -1 for unknown numeric values and "n/a" for unknown string values.
                 )
 
                 if days_limit != 0:
-                    updated_time_threshold = datetime.now() - timedelta(days=days_limit)
+                    updated_time_threshold = time_utils.current_datetime() - timedelta(
+                        days=days_limit
+                    )
                     display_logger.info(
                         f"Setting the updated_time_threshold to {updated_time_threshold}."
                     )

--- a/src/leettools/flow/metadata/_impl/duckdb/extract_metadata_manager_duckdb.py
+++ b/src/leettools/flow/metadata/_impl/duckdb/extract_metadata_manager_duckdb.py
@@ -37,6 +37,13 @@ class ExtractMetadataManagerDuckDB(AbstractExtractMetadataManager):
                     ]
                 )
             )
+        if ExtractMetadata.FIELD_KEY_FIELDS in extract_metadata_dict:
+            key_fields_str = extract_metadata_dict[ExtractMetadata.FIELD_KEY_FIELDS]
+            key_fields_str = key_fields_str[1:-1]
+            extract_metadata_dict[ExtractMetadata.FIELD_KEY_FIELDS] = (
+                key_fields_str.split(",")
+            )
+
         if ExtractMetadata.FIELD_VERIFY_FIELDS in extract_metadata_dict:
             verify_fields_str = extract_metadata_dict[
                 ExtractMetadata.FIELD_VERIFY_FIELDS
@@ -51,6 +58,13 @@ class ExtractMetadataManagerDuckDB(AbstractExtractMetadataManager):
         self, extract_metadata: ExtractMetadata
     ) -> Dict[str, Any]:
         extract_metadata_dict = extract_metadata.model_dump()
+        if ExtractMetadata.FIELD_KEY_FIELDS in extract_metadata_dict:
+            extract_metadata_dict[ExtractMetadata.FIELD_KEY_FIELDS] = (
+                "["
+                + ",".join(extract_metadata_dict[ExtractMetadata.FIELD_KEY_FIELDS])
+                + "]"
+            )
+
         if ExtractMetadata.FIELD_VERIFY_FIELDS in extract_metadata_dict:
             extract_metadata_dict[ExtractMetadata.FIELD_VERIFY_FIELDS] = (
                 "["

--- a/src/leettools/flow/metadata/extract_metadata_manager.py
+++ b/src/leettools/flow/metadata/extract_metadata_manager.py
@@ -41,11 +41,11 @@ class AbstractExtractMetadataManager(ABC):
         Retrieve the extracted database information for a given org and KB.
 
         Args:
-        -   org (Org): The organization object.
-        -   kb (KnowledgeBase): The knowledge base object.
+        - org (Org): The organization object.
+        - kb (KnowledgeBase): The knowledge base object.
 
         Returns:
-        -   Dict[str, List[ExtractionInfo]]: A dictionary containing the extracted
+        - Dict[str, List[ExtractionInfo]]: A dictionary containing the extracted
             database information, where the keys are the names of the tables and
             the values are lists of ExtractionInfo objects since we may have multiple
             extractions for a single table.

--- a/src/leettools/flow/steps/step_search_to_docsource.py
+++ b/src/leettools/flow/steps/step_search_to_docsource.py
@@ -3,7 +3,7 @@ from typing import ClassVar, List, Optional, Type
 
 from leettools.common import exceptions
 from leettools.common.logging import logger
-from leettools.common.utils import config_utils
+from leettools.common.utils import config_utils, time_utils
 from leettools.core.consts import flow_option
 from leettools.core.consts.docsource_status import DocSourceStatus
 from leettools.core.consts.docsource_type import DocSourceType
@@ -210,7 +210,7 @@ def _create_docsrc_for_search(
     display_logger.info(f"[Status]Searching the web with {retriever_type} ...")
 
     # use yyyy-mm-dd-hh-mm-ss to the URI to distinguish different searches
-    timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+    timestamp = time_utils.current_datetime().strftime("%Y-%m-%d-%H-%M-%S")
 
     docsource_create = DocSourceCreate(
         org_id=org.org_id,

--- a/src/leettools/web/scrapers/beautiful_soup/beautiful_soup.py
+++ b/src/leettools/web/scrapers/beautiful_soup/beautiful_soup.py
@@ -7,7 +7,7 @@ from bs4 import BeautifulSoup
 
 from leettools.common.logging import logger
 from leettools.common.logging.event_logger import EventLogger
-from leettools.common.utils import file_utils, url_utils
+from leettools.common.utils import file_utils, time_utils, url_utils
 from leettools.core.consts.return_code import ReturnCode
 from leettools.web.schemas.scrape_result import ScrapeResult
 from leettools.web.scrapers.scrapper import AbstractScrapper
@@ -74,7 +74,7 @@ class BeautifulSoupSimpleScraper(AbstractScrapper):
                 f"timestamp: {ts}"
             )
             # if the latest file is less than 1 day old, skip the scraping
-            now = datetime.now()
+            now = time_utils.current_datetime()
             diff: timedelta = now - ts
             # TODO: make the delta configurable
             if diff.days < 1:

--- a/src/leettools/web/scrapers/scraper_utils.py
+++ b/src/leettools/web/scrapers/scraper_utils.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 
 from leettools.common.logging.event_logger import EventLogger
-from leettools.common.utils import file_utils
+from leettools.common.utils import file_utils, time_utils
 from leettools.core.consts.return_code import ReturnCode
 from leettools.web.schemas.scrape_result import ScrapeResult
 
@@ -19,7 +19,7 @@ def check_existing_file(
             f"timestamp: {ts}"
         )
         # if the latest file is less than 1 day old, skip the scraping
-        now = datetime.now()
+        now = time_utils.current_datetime()
         diff: timedelta = now - ts
         # TODO: make the delta configurable
         if diff.days < 1:

--- a/tests/leettools/chat/test_chat_manager.py
+++ b/tests/leettools/chat/test_chat_manager.py
@@ -2,6 +2,7 @@ from typing import List
 
 from leettools.chat.history_manager import get_history_manager
 from leettools.chat.schemas.chat_history import ChatHistory, CHCreate, CHUpdate
+from leettools.common.logging import logger
 from leettools.common.temp_setup import TempSetup
 from leettools.context_manager import Context
 from leettools.core.consts.article_type import ArticleType
@@ -36,6 +37,7 @@ def test_chat_manager():
             _test_function(context, org, kb)
         finally:
             temp_setup.clear_tmp_org_kb_user(org, kb)
+            logger().info(f"Finished test for store_types: {store_types}")
 
 
 def _test_function(context: Context, org: Org, kb: KnowledgeBase):

--- a/tests/leettools/common/test_file_utils.py
+++ b/tests/leettools/common/test_file_utils.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 import leettools.common.utils.url_utils
-from leettools.common.utils import file_utils
+from leettools.common.utils import file_utils, time_utils
 
 
 def test_parse_uri_for_search_params():
@@ -79,7 +79,7 @@ def test_get_domain_from_url():
 
 
 def test_filename_timestamp_to_datetime():
-    now = datetime.now()
+    now = time_utils.current_datetime()
 
     filename_timestamp = file_utils.filename_timestamp(now)
 
@@ -93,7 +93,7 @@ def test_get_files_with_timestamp(tmp_path):
     prefix = "test"
     suffix = "txt"
 
-    ts_O1 = datetime.now()
+    ts_O1 = time_utils.current_datetime()
     timestamp_01 = file_utils.filename_timestamp(now=ts_O1)
     file_path_01 = f"{tmp_path}/{prefix}.{timestamp_01}.{suffix}"
     with open(file_path_01, "w") as file:
@@ -106,7 +106,7 @@ def test_get_files_with_timestamp(tmp_path):
     assert file_name == f"{prefix}.{timestamp_01}.{suffix}"
     assert ts_O1 == ts_01_read
 
-    ts_O2 = datetime.now()
+    ts_O2 = time_utils.current_datetime()
     timestamp_02 = file_utils.filename_timestamp(now=ts_O2)
     file_path_02 = f"{tmp_path}/{prefix}.{timestamp_02}.{suffix}"
     with open(file_path_02, "w") as file:

--- a/tests/leettools/core/repo/test_user_settings_store.py
+++ b/tests/leettools/core/repo/test_user_settings_store.py
@@ -66,7 +66,7 @@ def _test_settings_store(context: Context, org: Org, kb: KnowledgeBase, user: Us
     assert new_user_settings is not None
     assert new_user_settings.user_uuid == user.user_uuid
     assert new_user_settings.settings["OPENAI_API_KEY"].value == "new_key"
-    # when storing to DB, the datetime.now() may lose the microsecond
+    # when storing to DB, the time_utils.current_datetime() may lose the microsecond
     # 2024-04-20 23:44:18.609678 -> 2024-04-20 23:44:18.609000
     # so need to be careful when comparing the datetime
     assert new_user_settings.updated_at > user_settings.updated_at

--- a/tests/leettools/eds/extract/test_extract_store.py
+++ b/tests/leettools/eds/extract/test_extract_store.py
@@ -83,7 +83,7 @@ def _test_function(tmp_path, context: Context, org: Org, kb: KnowledgeBase, user
         active=True,
         metadata={"key": "value"},
         aliases=["alias1", "alias2"],
-        created_at=datetime.now(),
+        created_at=time_utils.current_datetime(),
         created_timestamp_in_ms=time_utils.cur_timestamp_in_ms(),
     )
 
@@ -94,7 +94,7 @@ def _test_function(tmp_path, context: Context, org: Org, kb: KnowledgeBase, user
         active=False,
         metadata={"key": "value"},
         aliases=["alias1", "alias2"],
-        created_at=datetime.now(),
+        created_at=time_utils.current_datetime(),
         created_timestamp_in_ms=time_utils.cur_timestamp_in_ms(),
     )
 


### PR DESCRIPTION
* Update KB related CLI for data extraction
* Add json output to doc list
* Fix extract_metadata_manager
* Update KB cli commands.
* Fix docsource ingestion cli
* Save reported news to DB
* Add word count, output language and style options to news, also change all timezone to UTC
* Save reported news to DB.
* Change all datetime to utc
* Add word count, output language and style options to news.
* Enforce to use local timezone since Duckdb does not supoort timezone by default.
* Remove redundant logging.
